### PR TITLE
add dependency for cluster-autoscaler namespace

### DIFF
--- a/infra/lib/addons/cluster-autoscaler.ts
+++ b/infra/lib/addons/cluster-autoscaler.ts
@@ -14,7 +14,7 @@ export class ClusterAutoscaler extends cdk.Construct {
     this.namespace = 'cluster-autoscaler';
 
     // Create namespace for CA
-    props.cluster.addManifest('CANamespace',
+    const ns = props.cluster.addManifest('CANamespace',
       {
         apiVersion: 'v1',
         kind: 'Namespace',
@@ -28,6 +28,8 @@ export class ClusterAutoscaler extends cdk.Construct {
     const sa = props.cluster.addServiceAccount('cluster-autoscaler', {
       namespace: this.namespace
     });
+
+    sa.node.addDependency(ns);
 
     const caPolicy = new iam.Policy(this, 'CAPolicy', {
       roles: [sa.role],
@@ -58,7 +60,7 @@ export class ClusterAutoscaler extends cdk.Construct {
       ]
     });
 
-    props.cluster.addHelmChart('CAHelm', {
+    const chart = props.cluster.addHelmChart('CAHelm', {
       chart: 'cluster-autoscaler-chart',
       release: 'ca',
       repository: 'https://kubernetes.github.io/autoscaler',
@@ -80,5 +82,6 @@ export class ClusterAutoscaler extends cdk.Construct {
         }
       }
     });
+    chart.node.addDependency(ns);
   }
 }


### PR DESCRIPTION
*Issue #, if available:* error of namespace not present for cluster-autoscaler

```
1:30:46 PM | CREATE_FAILED        | Custom::AWSCDK-EKS-KubernetesResource | Clusterclusterauto...ntResource3FADBE28
Failed to create resource. Error: b'Error from server (NotFound): error when creating "/tmp/manifest.yaml": namespaces "cluster-autoscaler" not foun
d\n'
Logs: /aws/lambda/InfraStack-awscdkawseksKubectlProv-Handler886CB40B-1EAAT3OUXYHO0
at invokeUserFunction (/var/task/framework.js:95:19)
at processTicksAndRejections (internal/process/task_queues.js:93:5)
at async onEvent (/var/task/framework.js:19:27)
at async Runtime.handler (/var/task/cfn-response.js:48:13)
        new CustomResource (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/@aws-cdk/aws-eks/node_modules/@aws-cdk/core/lib/c PM | ROLLBACK_IN_PROGRESS | AWS::CloudFormation::Stack            | InfraStack
ustom-resource.ts:119:21)
        \_ new KubernetesManifest (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/@aws-cdk/aws-eks/lib/k8s-manifest.ts:120:5 PM | DELETE_FAILED        | AWS::IAM::Role                        | WorkerRole
)
        \_ new ServiceAccount (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/@aws-cdk/aws-eks/lib/service-account.ts:90:5)5 PM | ROLLBACK_FAILED      | AWS::CloudFormation::Stack            | InfraStack
        \_ Cluster.addServiceAccount (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/@aws-cdk/aws-eks/lib/cluster.ts:716:12)
        \_ new ClusterAutoscaler (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/lib/addons/cluster-autoscaler.ts:28:30)
        \_ new InfraStack (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/lib/infra-stack.ts:71:5)
        \_ Object.<anonymous> (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/bin/infra.ts:7:1)
        \_ Module._compile (internal/modules/cjs/loader.js:1063:30)
        \_ Module.m._compile (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/ts-node/src/index.ts:1056:23)
        \_ Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
        \_ Object.require.extensions.<computed> [as .ts] (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/ts-node/src/index.t
s:1059:12)
        \_ Module.load (internal/modules/cjs/loader.js:928:32)
        \_ Function.Module._load (internal/modules/cjs/loader.js:769:14)
        \_ Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)
        \_ main (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/ts-node/src/bin.ts:198:14)
        \_ Object.<anonymous> (/home/ubuntu/environment/eks/cdk/aws-cdk-eks-fluxv2-example/infra/node_modules/ts-node/src/bin.ts:288:3)
        \_ Module._compile (internal/modules/cjs/loader.js:1063:30)
        \_ Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
```
*Description of changes:* add dependency for cluster-autoscaler namespace


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
