### PR TITLE
Do not wrap lines for RSA keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ metadata:
   name: github-keypair
   namespace: flux-system
 data:
-  known_hosts: $(ssh-keyscan -t rsa github.com 2>/dev/null|grep -E '^github\.com'|base64 -w 0)
-  identity: $(cat ${HOME}/.ssh/demo_key_rsa|base64 -w 0)
-  'identity.pub': $(cat ${HOME}/.ssh/demo_key_rsa.pub|base64 -w 0)
+  known_hosts: $(ssh-keyscan -t rsa github.com 2>/dev/null|grep -E '^github\.com'|base64|tr -d '\n')
+  identity: $(cat ${HOME}/.ssh/demo_key_rsa|base64|tr -d '\n')
+  'identity.pub': $(cat ${HOME}/.ssh/demo_key_rsa.pub|base64|tr -d '\n')
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ metadata:
   name: github-keypair
   namespace: flux-system
 data:
-  known_hosts: $(ssh-keyscan -t rsa github.com 2>/dev/null|grep -E '^github\.com'|base64)
-  identity: $(cat ${HOME}/.ssh/demo_key_rsa|base64)
-  'identity.pub': $(cat ${HOME}/.ssh/demo_key_rsa.pub|base64)
+  known_hosts: $(ssh-keyscan -t rsa github.com 2>/dev/null|grep -E '^github\.com'|base64 -w 0)
+  identity: $(cat ${HOME}/.ssh/demo_key_rsa|base64 -w 0)
+  'identity.pub': $(cat ${HOME}/.ssh/demo_key_rsa.pub|base64 -w 0)
 EOF
 ```
 


### PR DESCRIPTION
*Description of changes:*

The `base64` would wrap encoded lines at 76 chars each. Since RSA can be quite long many lines will confuse YAML parser.

An alternative would be to use YAML syntax accepting multi-line strings, but I find it finicky.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
